### PR TITLE
Added command line arguments and gradle properties

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 ### Gradle ###
 .gradle
 build/
+gradle.properties
 
 ### Racket Executables ### 
 connect-four-naive

--- a/build.gradle
+++ b/build.gradle
@@ -7,10 +7,19 @@ apply plugin: "application"
 task run_example {
     
     // default system is 'unix'
-    def i1 = "racket"
-    def p1 = "connect-four-naive.rkt"
-    def i2 = "racket"
-    def p2 = "connect-four-naive.rkt"
+    // I would prefer to use "racket" and not build, but defining
+    // the interpreter by default is not behavior I want.
+    //def i1 = "racket"
+    //def p1 = "connect-four-naive.rkt"
+    //def i2 = "racket"
+    //def p2 = "connect-four-naive.rkt"
+    def i1 = ""
+    def p1 = "./connect-four-naive"
+    def i2 = ""
+    def p2 = "./connect-four-naive"
+    
+    //build the examples?
+    //dependsOn(build_examples)
     
     if (project.hasProperty('system')) {
         if (system == "windows") {

--- a/build.gradle
+++ b/build.gradle
@@ -4,6 +4,41 @@ version = 'incubating'
 apply plugin: "java"
 apply plugin: "application"
 
+task run_example {
+    
+    // default system is 'unix'
+    def i1 = "racket"
+    def p1 = "connect-four-naive.rkt"
+    def i2 = "racket"
+    def p2 = "connect-four-naive.rkt"
+    
+    if (project.hasProperty('system')) {
+        if (system == "windows") {
+            i1 = "C:/Racket/Racket.exe"
+            i2 = "C:/Racket/Racket.exe"
+        } else if (system != "unix") {
+            throw new GradleException("unrecognized system '" + system + "'")
+        }
+        if (project.hasProperty('interpreter_1')) i1 = interpreter_1
+        if (project.hasProperty('interpreter_2')) i2 = interpreter_2
+        if (project.hasProperty('program_1')) p1 = program_1
+        if (project.hasProperty('program_2')) p2 = program_2
+        
+    } else {
+        println "Cannot run example without specifying 'system' property."
+        println "try: gradle -Psystem=unix run_example"
+        return
+    }
+    
+    run.args (
+        "--interpreter-1", i1,
+        "--program-1", p1,
+        "--interpreter-2", i2,
+        "--program-2", p2
+    )
+    finalizedBy(run)
+}
+
 sourceSets {
     main.java.srcDir "src/"
 }
@@ -26,3 +61,4 @@ jar.manifest.attributes(
     'Main-Class': mainClassName,
     'Class-Path': configurations.runtimeClasspath.files.collect { it.absolutePath }.join(' ')
 )
+

--- a/example.properties
+++ b/example.properties
@@ -1,0 +1,4 @@
+system=unix
+interpreter_1=racket
+program_1=connect-four-naive.rkt
+program_2=./connect-four-naive

--- a/src/ConnectFour/Main.java
+++ b/src/ConnectFour/Main.java
@@ -2,6 +2,7 @@
 package ConnectFour;
 
 import java.util.List;
+import java.util.LinkedList;
 import java.util.Arrays;
 import java.io.File;
 import java.io.IOException;
@@ -26,45 +27,96 @@ public class Main {
     // If the interpreter argument is used the program is
     // passed as an argument to it. The program args will
     // always be used.
-    // 
+    //
     public static void main(String[] args) { 
         
-        // Get these from command line arguments instead?
-        final int height = 7;
-        final int width = 8;
+        int height = 7;
+        int width = 8;
+        
+        String arg_i1 = "";
+        String arg_p1 = "";
+        String arg_i2 = "";
+        String arg_p2 = "";
+        
+        for (int i = 0; i < args.length; i++) {
+
+            if (!args[i].startsWith("--")) {
+                System.out.printf("unknown argument '%s'\n", args[i]);
+                return;
+            }
+
+            if (i+1 == args.length) {
+                System.out.printf("option '%s' requires value\n", args[i]);
+                return;
+            }
+            
+            switch (args[i]) {
+                case "--interpreter-1":
+                    arg_i1 = args[++i];
+                    break;
+                case "--program-1":
+                    arg_p1 = args[++i];
+                    break;
+                case "--interpreter-2":
+                    arg_i2 = args[++i];
+                    break;
+                case "--program-2":
+                    arg_p2 = args[++i];
+                    break;
+                case "--height":
+                    height = Integer.parseInt(args[++i]);
+                    break;
+                case "--width":
+                    width = Integer.parseInt(args[++i]);
+                    break;
+                default:
+                    System.out.printf("switch '%s' not recognized\n", args[i]);
+                    return;
+            }
+        }
         
         Board board = new Board(height, width, 4);
         PlayerProcess p1;
         PlayerProcess p2;
-
+        
         ProcessBuilder pb = new ProcessBuilder()
             .redirectError(Redirect.INHERIT)
             .directory(new File("src/examples"));
         
-        List<String> cmd1 = Arrays.asList(
-            //"./connect-four-naive",
-			//"C:/Racket/Racket.exe",
-			//"C:/SCHOOL FILES/CSCI 3508 (Intro to Software Engineering)/Team-9-Driver/Team-9-Driver/src/examples/connect-four-naive.rkt",
+        List<String> cmd1 = new LinkedList<String>(Arrays.asList(
             "--player", "1",
             "--height", Integer.toString(height),
             "--width", Integer.toString(width)
-        );
+        ));
         
-        List<String> cmd2 = Arrays.asList(
-            //"julia",
-            //"connect-four-naive.jl",
-			//"C:/Racket/Racket.exe",
-			//"C:/SCHOOL FILES/CSCI 3508 (Intro to Software Engineering)/Team-9-Driver/Team-9-Driver/src/examples/connect-four-naive.rkt",
-            //"./connect-four-scoring",
+        List<String> cmd2 = new LinkedList<String>(Arrays.asList(
             "--player", "2",
             "--height", Integer.toString(height),
             "--width", Integer.toString(width)
-        );
+        ));
+        
+        cmd1.add(0, arg_p1);
+        if (!arg_i1.equals(""))
+            cmd1.add(0, arg_i1);
+        
+        cmd2.add(0, arg_p2);
+        if (!arg_i2.equals(""))
+            cmd2.add(0, arg_i2);
+        
+        //if (!arg_p1.equals(""))
+        //    cmd1.add(0, arg_p1);
+        //cmd1.add(0, arg_i1);
+        //
+        //if (!arg_p2.equals(""))
+        //    cmd2.add(0, arg_p2);
+        //cmd2.add(0, arg_i2);
         
         try {
             
+            //System.out.println("DEBUG: " + cmd1);
+            //System.out.println("DEBUG: " + cmd2);
             p1 = new PlayerProcess(pb.command(cmd1).start());
-            p2 = new PlayerProcess(pb.command(cmd1).start());
+            p2 = new PlayerProcess(pb.command(cmd2).start());
             
             int winner;
             while (true) {


### PR DESCRIPTION
Fixes #2

I've added command line arguments. With these, we can now specify the interpreters to run, the programs, as well as the height and width. Using grade, these parameters can be specified. Currently, gradle only acknowledges the interpreter and programs, but we can change that. Either way, you should be able to use the `--args=` option for `gradle run`.

This means, no more changing the commands in the code directly! When I test something on my computer, it will not conflict with what you guys test on Windows.

To use gradle properties you can do the following:
1) Run `gradle -Psystem=windows run_example`
2) Copy `example.properties` to `gradle.properties`, then change `racket` to `C:/Racket/Racket.exe` (or whatever the windows equivalent is).

The gradle build file has potential to be changed in the future for more features and support options.

-----

EDIT: Before this is pulled in, I'd like to make sure it works on a windows computer.